### PR TITLE
Add new 1.19.30 symbols

### DIFF
--- a/include/minecraft/imported/android_symbols.h
+++ b/include/minecraft/imported/android_symbols.h
@@ -45,5 +45,8 @@ static const char* android_symbols[] = {
         "AAssetDir_getNextFileName",
         "AAssetDir_close",
         "AAssetManager_fromJava",
+        "gettid",
+        "sched_get_priority_min",
+        "sched_get_priority_max",
         nullptr
 };


### PR DESCRIPTION
1.19.30 betas seem to have the gettid, sched_get_priority_min, and sched_get_priority_max symbols. Adding all of them to android_symbols.h makes the game work as normal for me without any additional changes.